### PR TITLE
Solution to #58

### DIFF
--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1164,7 +1164,7 @@ function SelectRoles(plys, max_plys)
 	for _, v in ipairs(player.GetAll()) do
 
 		-- everyone on the spec team is in specmode
-		if IsValid(v) and not v:GetForceSpec() and (not plys or table.HasValue(plys, v)) then
+		if IsValid(v) and not v:GetForceSpec() and (not plys or table.HasValue(plys, v)) and not (v.AutoslaysLeft and tonumber(v.AutoslaysLeft) > 0) then
 			if not plys then
 				tmp[#tmp + 1] = v
 			end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1164,7 +1164,7 @@ function SelectRoles(plys, max_plys)
 	for _, v in ipairs(player.GetAll()) do
 
 		-- everyone on the spec team is in specmode
-		if IsValid(v) and not v:GetForceSpec() and (not plys or table.HasValue(plys, v)) and not (v.AutoslaysLeft and tonumber(v.AutoslaysLeft) > 0) then
+		if IsValid(v) and not v:GetForceSpec() and (not plys or table.HasValue(plys, v)) and (Damagelog and Damagelog.ULX_Autoslay_ForceRole and not (v.AutoslaysLeft and tonumber(v.AutoslaysLeft) > 0)) then
 			if not plys then
 				tmp[#tmp + 1] = v
 			end


### PR DESCRIPTION
Checks both if Damagelog exists, and if it does it will then check for the ForceRole config boolean.

If it's true, will ignore people with Autoslays.

This is not an "end-all be-all" solution, as it requires small editing of Damagelogs (mainly removing from [this line](https://github.com/Tommy228/tttdamagelogs/blob/289535fe540b1aaa7fe346b012d3e201f55a2775/lua/damagelogs/server/autoslay.lua#L420) down).