### PR TITLE
Fix for default credit system

### DIFF
--- a/gamemodes/terrortown/gamemode/cl_targetid_main.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid_main.lua
@@ -44,7 +44,7 @@ function GM:PostDrawTranslucentRenderables()
 	local client = LocalPlayer()
 	local plys = GetPlayers()
 
-	--if client:IsActive() and client:IsSpecial() then
+	if client:IsSpecial() then
 		dir = (client:GetForward() * -1)
 
 		for i = 1, #plys do
@@ -57,7 +57,6 @@ function GM:PostDrawTranslucentRenderables()
 			if ply ~= client
 			and ply:IsActive()
 			and ply:IsSpecial()
-			and (ply:IsInTeam(client) or ply:GetRole() == ROLE_DETECTIVE)
 			and not ply:GetSubRoleData().avoidTeamIcons
 			then
 				local base = Material("vgui/ttt/dynamic/sprite_base")
@@ -80,7 +79,7 @@ function GM:PostDrawTranslucentRenderables()
 				render.DrawQuadEasy(pos, dir, 7, 7, Color(255, 255, 255, 255), 180)
 			end
 		end
-	--end
+	end
 
 	if client:Team() == TEAM_SPEC then
 		cam.Start3D(EyePos(), EyeAngles())

--- a/gamemodes/terrortown/gamemode/cl_targetid_main.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid_main.lua
@@ -44,7 +44,7 @@ function GM:PostDrawTranslucentRenderables()
 	local client = LocalPlayer()
 	local plys = GetPlayers()
 
-	if client:IsActive() and client:IsSpecial() then
+	--if client:IsActive() and client:IsSpecial() then
 		dir = (client:GetForward() * -1)
 
 		for i = 1, #plys do
@@ -57,7 +57,7 @@ function GM:PostDrawTranslucentRenderables()
 			if ply ~= client
 			and ply:IsActive()
 			and ply:IsSpecial()
-			and ply:IsInTeam(client)
+			and (ply:IsInTeam(client) or ply:GetRole() == ROLE_DETECTIVE)
 			and not ply:GetSubRoleData().avoidTeamIcons
 			then
 				local base = Material("vgui/ttt/dynamic/sprite_base")
@@ -80,7 +80,7 @@ function GM:PostDrawTranslucentRenderables()
 				render.DrawQuadEasy(pos, dir, 7, 7, Color(255, 255, 255, 255), 180)
 			end
 		end
-	end
+	--end
 
 	if client:Team() == TEAM_SPEC then
 		cam.Start3D(EyePos(), EyeAngles())

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -784,6 +784,7 @@ function BeginRound()
 	-- anymore.
 	DEBUGP("000000")
 	SelectRoles()
+	SendDefaultCredits()
 	DEBUGP("000001")
 	LANG.Msg("round_selected")
 	DEBUGP("000002")
@@ -1396,9 +1397,6 @@ function SelectRoles(plys, max_plys)
 
 		ply:SetRole(subrole)
 
-		-- initialize credit count for everyone based on their role
-		ply:SetDefaultCredits()
-
 		-- store a steamid -> role map
 		GAMEMODE.LastRole[ply:SteamID64()] = subrole
 	end
@@ -1410,6 +1408,14 @@ function SelectRoles(plys, max_plys)
 	SendFullStateUpdate() -- theoretically not needed
 
 	DEBUGP("00001D")
+end
+
+function SendDefaultCredits()
+	for _, v in ipairs(player.GetAll()) do
+		if IsValid(v) then
+			v:SetDefaultCredits()
+		end
+	end
 end
 
 local function ttt_roundrestart(ply, command, args)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -784,7 +784,6 @@ function BeginRound()
 	-- anymore.
 	DEBUGP("000000")
 	SelectRoles()
-	SendDefaultCredits()
 	DEBUGP("000001")
 	LANG.Msg("round_selected")
 	DEBUGP("000002")
@@ -1400,6 +1399,11 @@ function SelectRoles(plys, max_plys)
 		-- store a steamid -> role map
 		GAMEMODE.LastRole[ply:SteamID64()] = subrole
 	end
+	
+	-- just set the credits after all roles were selected (to fix alone traitor bug)
+	for _, ply in ipairs(plys) do
+		ply:SetDefaultCredits()
+	end
 
 	DEBUGP("00001C")
 
@@ -1408,14 +1412,6 @@ function SelectRoles(plys, max_plys)
 	SendFullStateUpdate() -- theoretically not needed
 
 	DEBUGP("00001D")
-end
-
-function SendDefaultCredits()
-	for _, v in ipairs(player.GetAll()) do
-		if IsValid(v) then
-			v:SetDefaultCredits()
-		end
-	end
 end
 
 local function ttt_roundrestart(ply, command, args)

--- a/gamemodes/terrortown/gamemode/player_ext_main.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_main.lua
@@ -68,7 +68,6 @@ end
 function plymeta:SetDefaultCredits()
 	if hook.Run("TTT2SetDefaultCredits", self) then return end
 
-	timer.Simple(0, function()
 	if self:IsShopper() then
 		local rd = self:GetSubRoleData()
 		local name = rd.index == ROLE_TRAITOR and "ttt_credits_starting" or "ttt_" .. rd.abbr .. "_credits_starting"
@@ -92,7 +91,6 @@ function plymeta:SetDefaultCredits()
 	else
 		self:SetCredits(0)
 	end
-	end)
 
 end
 

--- a/gamemodes/terrortown/gamemode/player_ext_main.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_main.lua
@@ -73,25 +73,30 @@ function plymeta:SetDefaultCredits()
 		local name = rd.index == ROLE_TRAITOR and "ttt_credits_starting" or "ttt_" .. rd.abbr .. "_credits_starting"
 
 		if self:HasTeam(TEAM_TRAITOR) then
-			local c = (ConVarExists(name) and GetConVar(name):GetInt()) or 0
-			if not rd.preventTraitorAloneCredits and #GetTeamMembers(TEAM_TRAITOR) == 1 then
-				c = c + (ConVarExists("ttt_credits_alonebonus") and GetConVar("ttt_credits_alonebonus"):GetInt()) or 0
+			local c = (ConVarExists(name) and GetConVar(name):GetFloat()) or 0
+			local member_count = #GetTeamMembers(TEAM_TRAITOR) 
+			
+			if not rd.preventTraitorAloneCredits and member_count == 1 then
+				c = c + (ConVarExists("ttt_credits_alonebonus") and GetConVar("ttt_credits_alonebonus"):GetFloat()) or 0
 			end
 			
-			if #GetTeamMembers(TEAM_TRAITOR) > 1 then
-				c = c - (#GetTeamMembers(TEAM_TRAITOR)-1)
+			c = math.ceil(c)
+			
+			if member_count > 1 then
+				c = c + 1 - member_count
 			end
 			
-			if c <= 0 then c = 1 end
+			if c <= 0 then 
+				c = 1 
+			end
 
-			self:SetCredits(math.ceil(c))
+			self:SetCredits(c)
 		else
-			self:SetCredits(math.ceil(ConVarExists(name) and GetConVar(name):GetInt() or 0))
+			self:SetCredits(math.ceil((ConVarExists(name) and GetConVar(name):GetFloat()) or 0))
 		end
 	else
 		self:SetCredits(0)
 	end
-
 end
 
 function plymeta:SendCredits()

--- a/gamemodes/terrortown/gamemode/player_ext_main.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_main.lua
@@ -68,16 +68,22 @@ end
 function plymeta:SetDefaultCredits()
 	if hook.Run("TTT2SetDefaultCredits", self) then return end
 
+	timer.Simple(0, function()
 	if self:IsShopper() then
 		local rd = self:GetSubRoleData()
 		local name = rd.index == ROLE_TRAITOR and "ttt_credits_starting" or "ttt_" .. rd.abbr .. "_credits_starting"
 
 		if self:HasTeam(TEAM_TRAITOR) then
 			local c = (ConVarExists(name) and GetConVar(name):GetInt()) or 0
-
 			if not rd.preventTraitorAloneCredits and #GetTeamMembers(TEAM_TRAITOR) == 1 then
 				c = c + (ConVarExists("ttt_credits_alonebonus") and GetConVar("ttt_credits_alonebonus"):GetInt()) or 0
 			end
+			
+			if #GetTeamMembers(TEAM_TRAITOR) > 1 then
+				c = c - (#GetTeamMembers(TEAM_TRAITOR)-1)
+			end
+			
+			if c <= 0 then c = 1 end
 
 			self:SetCredits(math.ceil(c))
 		else
@@ -86,6 +92,8 @@ function plymeta:SetDefaultCredits()
 	else
 		self:SetCredits(0)
 	end
+	end)
+
 end
 
 function plymeta:SendCredits()


### PR DESCRIPTION
This will fix the default credit system and also adds the "old" mechanic of "the more traitors, the less credits" back.

To alf: Just edit everything to your needs if needed (Maybe a setting to disable the "old" mechanic?), and also ignore the cl_targetid_main..