### PR TITLE
Fix for fake corpses and rare occasions

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -477,7 +477,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
 
 	-- if someone searches this body they can find info on the victim and the
 	-- death circumstances
-	rag.equipment = ply:GetEquipmentItems()
+	rag.equipment = table.Copy(ply:GetEquipmentItems())
 	rag.was_role = ply:GetSubRole()
 	rag.role_color = ply:GetRoleColor()
 


### PR DESCRIPTION
Fixed bug (well actually just cloning the table..) where fake corpses and sometimes normal corpses would update the Equipments of a Player even if the corpse was already confirmed / created.

Not neccessary to merge, but It's defenetly an advantage for players that know this bug (on my servers they know it and can confirm traitors very very easily).