### PR TITLE
Binds: Fix saving removal of binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed foregoing fetch fix
 - Fixed HUD savingKeys variable not being unique across all HUDs
 - Fixed drawing web images, seamless web images and avatar images
+- Fixed correctly saving setting a bind to NONE, while a default is defined
 
 ## [v0.7.3b](https://github.com/TTT-2/TTT2/tree/v0.7.3b) (2020-08-09)
 

--- a/lua/bind/cl_init.lua
+++ b/lua/bind/cl_init.lua
@@ -30,7 +30,7 @@ local function DBCreateBindsTable()
 		local result = sql.Query("CREATE TABLE " .. BIND_TABLE_NAME .. " (guid TEXT, name TEXT, button TEXT)")
 
 		if result == false then
-			print("[TTT2][BIND][ERROR] Could not create the database table...")
+			ErrorNoHalt("[TTT2][BIND][ERROR] Could not create the database table...")
 
 			return false
 		end
@@ -46,7 +46,7 @@ local function DBCreateDefaultBindsFlagTable()
 		local result = sql.Query("CREATE TABLE " .. BIND_FLAG_TABLE_NAME .. " (guid TEXT, name TEXT)")
 
 		if result == false then
-			print("[TTT2][BIND][ERROR] Could not create the flag database table...")
+			ErrorNoHalt("[TTT2][BIND][ERROR] Could not create the flag database table...")
 
 			return false
 		end
@@ -62,7 +62,7 @@ local function SaveBinding(name, button)
 		local result = sql.Query("INSERT INTO " .. BIND_TABLE_NAME .. " VALUES('" .. LocalPlayer():SteamID64() .. "', " .. sql.SQLStr(name) .. ", " .. sql.SQLStr(button) .. ")")
 
 		if result == false then
-			print("[TTT2][BIND][ERROR] Wasn't able to save binding to database...")
+			ErrorNoHalt("[TTT2][BIND][ERROR] Wasn't able to save binding to database...")
 		end
 	end
 end
@@ -74,7 +74,7 @@ local function DBRemoveBinding(name, button)
 		local result = sql.Query("DELETE FROM " .. BIND_TABLE_NAME .. " WHERE guid = '" .. LocalPlayer():SteamID64() .. "' AND name = " .. sql.SQLStr(name) .. " AND button = " .. sql.SQLStr(button) )
 
 		if result == false then
-			print("[TTT2][BIND][ERROR] Wasn't able to remove binding from database...")
+			ErrorNoHalt("[TTT2][BIND][ERROR] Wasn't able to remove binding from database...")
 		end
 	end
 end
@@ -86,7 +86,7 @@ local function DBSetDefaultAppliedFlag(name)
 		local result = sql.Query("INSERT INTO " .. BIND_FLAG_TABLE_NAME .. " VALUES('" .. LocalPlayer():SteamID64() .. "', " .. sql.SQLStr(name) .. ")")
 
 		if result == false then
-			print("[TTT2][BIND][ERROR] Wasn't able to save binding flag to database...")
+			ErrorNoHalt("[TTT2][BIND][ERROR] Wasn't able to save binding flag to database...")
 		end
 	end
 end
@@ -106,7 +106,6 @@ end
 ---
 -- @internal
 local function TTT2LoadBindings()
-
 	if DBCreateBindsTable() then
 		local result = sql.Query("SELECT * FROM " .. BIND_TABLE_NAME .. " WHERE guid = '" .. LocalPlayer():SteamID64() .. "'")
 
@@ -138,7 +137,6 @@ local function TTT2LoadBindings()
 			-- and always set the applied flag.
 			DBSetDefaultAppliedFlag(name)
 		end
-
 	end
 end
 


### PR DESCRIPTION
This patch adds another table to the binds database, to check if the default key was already "set". This differs from before, where on each load, the default key binds were restored, because no entry existed in the database (as entries are removed once they are unassigned). Now the default key will only be added once if no key bind is already selected and after that won't be assigned anymore. 

Some minor adjustments to the general bind code also had to be made (See respective commits).
