### PR TITLE
EntSpawnRework: Pointshop2 fix

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -250,9 +250,13 @@ end
 -- @ref https://wiki.facepunch.com/gmod/GM:PlayerSetModel
 -- @local
 function GM:PlayerSetModel(ply)
+	-- The player modes has to be applied here since some player model selectors overwrite
+	-- this hook to suppress the TTT2 player models. If the model is assigned elsewhere, it
+	-- breaks with external model selectors.
 	if not IsValid(ply) then return end
 
-	ply:SetModel(ply.defaultModel or GAMEMODE.playermodel) -- this will call the overwritten internal function to modify the model
+	-- this will call the overwritten internal function to modify the model
+	ply:SetModel(ply.defaultModel or GAMEMODE.playermodel)
 
 	-- Always clear color state, may later be changed in TTTPlayerSetColor
 	ply:SetColor(COLOR_WHITE)

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -636,20 +636,6 @@ function plymeta:SpawnForRound(deadOnly)
 	self:SetTeam(TEAM_TERROR)
 	self:Spawn()
 
-	-- this will call the overwritten internal function to modify the model
-	--self:SetModel(self.defaultModel or GAMEMODE.playermodel)
-
-	---
-	-- @realm server
-	--hook.Run("PlayerSetModel", self)
-
-	-- Always clear color state, may later be changed in TTTPlayerSetColor
-	--self:SetColor(COLOR_WHITE)
-
-	---
-	-- @realm server
-	--hook.Run("TTTPlayerSetColor", self)
-
 	-- set spawn position
 	local spawnPoint = plyspawn.GetRandomSafePlayerSpawnPoint(self)
 


### PR DESCRIPTION
Reverted the way how the player models are applied to the old way, since it broke compatibility to Pointshop2. Commit that brole it: https://github.com/TTT-2/TTT2/pull/837/commits/695b26b98f08b7495f3d6b102865f6f807bc4701