### PR TITLE
SQL: Loading "NULL" entries of database fixed

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_sql.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_sql.lua
@@ -26,12 +26,12 @@ function sql.GetParsedData(key, data, res)
 
 	local val = res[key]
 
+	if val == "NULL" then
+		return nil
+	end
+
 	if data.typ == "number" then
-		if val == "NULL" then
-			val = 0
-		else
-			val = tonumber(val)
-		end
+		val = tonumber(val)
 	elseif data.typ == "bool" then
 		val = val == "1"
 	elseif data.typ == "pos" then


### PR DESCRIPTION
Loading sql data with unitinialized data lead to wrong behaviour like numbers assuming the value 0 and booleans being false. Now they return just nil and get skipped.

So now, unitialized weapons are no longer not AutoSpawnable and work like before the weapon spawn rework.