### PR TITLE
Markervision: Fixed another null entity error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
-- Fixed markerVision null entity error (by @mexikoedi)
+- Fixed markerVision null entity errors (by @mexikoedi)
 
 ## [v0.14.5b](https://github.com/TTT-2/TTT2/tree/v0.14.5b) (2025-08-18)
 

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -46,12 +46,14 @@ function markerVision.Add(ent, identifier)
     -- Overwrite the entity's UpdateTransmitState function to TRANSMIT_ALWAYS.
     -- This is necessary because otherwise the entity might get culled.
     -- Before we overwrite the function, we save the old function to restore it later.
-    ent.ttt2MVTransmitOldFunc = ent.UpdateTransmitState
+    if IsValid(ent) then
+        ent.ttt2MVTransmitOldFunc = ent.UpdateTransmitState
 
-    ent.UpdateTransmitState = function()
-        return TRANSMIT_ALWAYS
+        ent.UpdateTransmitState = function()
+            return TRANSMIT_ALWAYS
+        end
+        ent:AddEFlags(EFL_FORCE_CHECK_TRANSMIT)
     end
-    ent:AddEFlags(EFL_FORCE_CHECK_TRANSMIT)
 
     return mvObject
 end


### PR DESCRIPTION
This PR fixes the following error:
```
[REDACTED] Lua Error:

[TTT2 (Base) - v0.14.5b] lua/ttt2/libraries/marker_vision.lua:54: Tried to use a NULL entity!
  1. AddEFlags - [C]:-1
   2. Add - lua/ttt2/libraries/marker_vision.lua:54
    3. callback - lua/ttt2/libraries/marker_vision.lua:230
     4. func - lua/ttt2/extensions/net.lua:206
      5. unknown - lua/includes/extensions/net.lua:34
```

The null entity error was introduced in https://github.com/TTT-2/TTT2/pull/1825 .

I tested it and I couldn't reproduce the above error again.

(I fixed a similar error in the following PR but I didn't notice the other error: https://github.com/TTT-2/TTT2/pull/1835 )
