### PR TITLE
Contributing: Adjusted outdated information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,6 @@ Please follow the respective guidelines below to support a good experience for e
 - Make sure your issue is related to the ttt2 gamemode, other issues belong in their respective addon/role repositories.
 - For **bug reports** be sure to fill out the provided template.
 - For **feature requests** be as descriptive as possible.
-  - if you want to suggest a role or an addon please visit our [addon ideas repository](https://github.com/TTT-2/addon-ideas/issues) and open an issue there.
+  - if you want to suggest a role or an addon please visit our [discussion area](https://github.com/TTT-2/TTT2/discussions) and open a new discussion there.
 
 If you want to discuss this and other addons just [join our discord server](https://discord.gg/9njYXGY).


### PR DESCRIPTION
This PR removed outdated information from the CONTRIBUTING file and replaced it with newer information.

I also checked some other places (README, DESIGNGUIDLINES, RELEASE_PROCESS and the Steam Workshop page) for dead urls/outdated information/... and found only one issue:
- At the [Steam Workshop page of TTT2 Base ](https://steamcommunity.com/sharedfiles/filedetails/?id=1357204556) under "ADDONS" there is an url for an example for the addonchecker with the name "looks like this" which is not available anymore. This should be replaced with for example this url: https://docs.ttt2.neoxult.de/troubleshooting/#addon-checker