### PR TITLE
Fixed GetHeadshotMultiplier nil value error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed missing ttt_filter_role in ttt2.fgd (by @mrxonte)
 - Fixed loading screen tips translation (by @mexikoedi)
 - Fixed missing `limit_left` translation (by @mexikoedi)
+- Fixed `GetHeadshotMultiplier` nil value error (by @mexikoedi)
 
 ## [v0.14.5b](https://github.com/TTT-2/TTT2/tree/v0.14.5b) (2025-08-18)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1110,7 +1110,12 @@ function GM:ScalePlayerDamage(ply, hitgroup, dmginfo)
 
         if IsValid(wep) then
             ---@cast wep -nil
-            local s = wep:GetHeadshotMultiplier(ply, dmginfo) or 2
+            local s = 2
+
+            -- only call GetHeadshotMultiplier if the weapon provides it
+            if isfunction(wep.GetHeadshotMultiplier) then
+                s = wep:GetHeadshotMultiplier(ply, dmginfo) or s
+            end
 
             dmginfo:ScaleDamage(s)
         end


### PR DESCRIPTION
This PR fixes the following error:
```
[TTT2 (Base) - v0.14.5b] gamemodes/terrortown/gamemode/server/sv_player.lua:1113: attempt to call method 'GetHeadshotMultiplier' (a nil value)
  1. unknown - gamemodes/terrortown/gamemode/server/sv_player.lua:1113
```

The error appeared on this map: [[TTT] ttt_terminus_v1](https://steamcommunity.com/sharedfiles/filedetails/?id=371886156)

If you are a Traitor you can call combine policemen.
Some of them have pistols and these are not compatible with TTT/TTT2.
You get this error if you try to pick up the pistol:
```
[TTT2 (Base) - v0.14.5b] Equipped weapon weapon_pistol is not compatible with TTT
  1. unknown - gamemodes/terrortown/gamemode/server/sv_weaponry.lua:529
```
This is correct because you shouldn't be able to pick up weapons which aren't compatible.

But if they hit you in the head with the pistol it causes the above `GetHeadshotMultiplier` error which shouldn't happen.

I tested this PR and the combine policemen didn't cause this error anymore if the hit the head of a player.