### PR TITLE
Remove GmodAdminSuite from incompatible list

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -211,10 +211,6 @@ addonChecker.curatedList = {
         reason = "This addon messes with some core TTT(2) functions, creating issues like corpses being recognized as 'fake' even though they are not.",
         type = ADDON_INCOMPATIBLE,
     },
-    ["1595332211"] = { -- GmodAdminSuite by Methylenedioxymethamphetamine
-        reason = "Breaks the weapon pickup.",
-        type = ADDON_INCOMPATIBLE,
-    },
     ["456247192"] = { -- TTT Coffee-Cup Hunt by Niandra!
         alternative = "2150924507",
         reason = "Addon is broken and doesn't do anything.",


### PR DESCRIPTION
Issue has been fixed.

Please get in touch next time.

It took 5 months for me to be made aware of this. GmodAdminSuite is an actively maintained addon.

Apologies if you already tried to get in touch but weren't able to.