### PR TITLE
Karma: Improved karma health scaling

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -676,7 +676,11 @@ function KARMA.NotifyPlayer(ply)
             LANG.Msg(ply, "karma_dmg_other", { amount = k, num = math.ceil((1 - df) * 100) })
         end
         if config.healthscaling:GetBool() then
-            LANG.Msg(ply, "karma_hp_other", { amount = k, num = math.ceil(100 - (health + (100 - health) * df)) })
+            LANG.Msg(
+                ply,
+                "karma_hp_other",
+                { amount = k, num = math.ceil(100 - (health + (100 - health) * df)) }
+            )
         end
     end
 end

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -660,6 +660,7 @@ end
 -- @param Player ply
 -- @realm server
 function KARMA.NotifyPlayer(ply)
+    local health = KARMA.GetHealthMin()
     local df = ply:GetDamageFactor() or 1
     local k = math.Round(ply:GetBaseKarma())
 
@@ -675,7 +676,7 @@ function KARMA.NotifyPlayer(ply)
             LANG.Msg(ply, "karma_dmg_other", { amount = k, num = math.ceil((1 - df) * 100) })
         end
         if config.healthscaling:GetBool() then
-            LANG.Msg(ply, "karma_hp_other", { amount = k })
+            LANG.Msg(ply, "karma_hp_other", { amount = k, num = math.ceil(100 - (health + (100 - health) * df)) })
         end
     end
 end

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -155,10 +155,7 @@ function GM:PlayerSpawn(ply)
 
     if KARMA.IsHealthScalingEnabled() then
         local health = KARMA.GetHealthMin()
-        local df
-        if ply.GetDamageFactor then
-            df = ply:GetDamageFactor() or 1
-        end
+        local df = ply:GetDamageFactor() or 1
 
         health = health + (100 - health) * df
         ply:SetMaxHealth(health)

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -155,7 +155,12 @@ function GM:PlayerSpawn(ply)
 
     if KARMA.IsHealthScalingEnabled() then
         local health = KARMA.GetHealthMin()
-        health = health + (100 - health) * (ply:GetBaseKarma() / KARMA.GetKarmaMax())
+        local df
+        if ply.GetDamageFactor then
+            df = ply:GetDamageFactor() or 1
+        end
+
+        health = health + (100 - health) * df
         ply:SetMaxHealth(health)
         ply:SetHealth(health)
     end

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -52,7 +52,7 @@ L.credit_kill = "You have received {num} credit(s) for killing a {role}."
 L.karma_dmg_full = "Your Karma is {amount}, so you deal full damage this round!"
 L.karma_dmg_other = "Your Karma is {amount}. As a result all damage you deal is reduced by {num}%"
 L.karma_hp_full = "Your Karma is {amount}, so you get full HP this round!"
-L.karma_hp_other = "Your Karma is {amount}. As a result your maximum HP is reduced"
+L.karma_hp_other = "Your Karma is {amount}. As a result your maximum HP is reduced by {num} HP"
 
 -- Body identification messages
 L.body_found = "{finder} found the body of {victim}. {role}"


### PR DESCRIPTION
I tried the karma health scaling and noticed an issue:
I started a round with 1000 karma points (default starting karma convar) and I got the text in the upper right corner that I do max damage and have max health this round but my health is only 90. 
This happened because the maximum karma convar was at 1250 (higher than the starting karma convar).

So I looked into it:
- If I have starting karma at 1000 and max karma at 1250 and health scaling is enabled and the min health is 50 then it triggers this message: https://github.com/TTT-2/TTT2/pull/1864/changes#diff-5d20027aa8a8495685d15cc67a295077101c5c93de1baa6cd19d7f44b19fb55bR671
- That happens because `df` was 1 and `k` was 1000 (it uses `GetBaseKarma()` which uses the starting karma amount (1000))
- But I still have only 90 health points because the calculation here: https://github.com/TTT-2/TTT2/pull/1864/changes#diff-9a3b416f9d1a5498e05bb17440872599ed2ba1bccf94ebcbde4c259a57abd3baR158 uses `GetKarmaMax()` which is set to 1250

Karma max convar is only there to provide a buffer (starting karma | max karma) and shouldn't influence health scaling.
I adjusted the calculation and now the messages appear correct and it's more consistent with the damage scaling.

Some examples:
Karma starting convar is at 1000 and Karma max convar is at 1250 in these examples.

- Karma min health convar is at 0 and I start a round:
-> I have 100 health points and the messages display correctly (full damage and full health)

- Karma min health convar is at 0 and I start the next round but now I set my karma to 0:
-> I have 10 health points and the messages say I do 90% less damage and I have 90 HP less

- Karma min health convar is at 0 and I start the next round but now I set my karma to 500:
-> I have 15 health points and the messages say I do 85% less damage and I have 85 HP less

- Karma min health convar is at 50 and I start the next round but now I set my karma to 500:
-> I have 57 health points and the messages say I do 85% less damage and I have 43 HP less

- Karma min health convar is at 50 and I start the next round but now I set my karma to 750:
-> I have 85 health points and the messages say I do 31% less damage and I have 15 HP less

So it seems to be working fine now.
Now it's more consistent with the damage scaling and the message works correctly (and also displays the lost health points).