### PR TITLE
Fix DTooltipTTT2 assigning random globals

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
@@ -86,7 +86,8 @@ function PANEL:PositionTooltip()
 
     if self.targetPanel:HasTooltipFixedPosition() then
         x, y = self.targetPanel:GetTooltipFixedPosition()
-        parentX, parentY = self.targetPanel:GetParent():LocalToScreen(self.targetPanel:GetPos())
+        local parentX, parentY =
+            self.targetPanel:GetParent():LocalToScreen(self.targetPanel:GetPos())
 
         x = x + parentX
         y = y + parentY


### PR DESCRIPTION
I can only assume this was just a silly mistake whenever this was last touched. I don't imagine it really affects anything though.