### PR TITLE
Add momentary_rot_button to TargetID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added momentary_rot_button to targetID (by @MrXonte)
+
 ## [v0.14.6b](https://github.com/TTT-2/TTT2/tree/v0.14.6b) (2026-04-06)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/shared/sh_entity.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_entity.lua
@@ -34,9 +34,17 @@ function entmeta:IsRotatingButton()
 end
 
 ---
+-- Returns true if this entity is a momentary rotating button (lever).
+-- @return boolean Returns true if momentary rotating button
+-- @realm shared
+function entmeta:IsMomentaryRotatingButton()
+    return button.IsClass(self, "momentary_rot_button")
+end
+
+---
 -- Returns true if the entity is any type of button.
 -- @return boolean Returns true if button
 -- @realm shared
 function entmeta:IsButton()
-    return self:IsDefaultButton() or self:IsRotatingButton()
+    return self:IsDefaultButton() or self:IsRotatingButton() or self:IsMomentaryRotatingButton()
 end

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2356,9 +2356,11 @@ L.label_roles_derandomize_min_weight = "Derandomization minimum weight"
 -- 2024-08-17
 L.name_button_default = "Button"
 L.name_button_rotating = "Lever"
+L.name_button_momentary_rotating = "Wheel"
 
 L.button_default = "Press [{usekey}] to trigger"
 L.button_rotating = "Press [{usekey}] to flip"
+L.button_momentary_rotating = "Press [{usekey}] to rotate"
 
 L.undefined_key = "???"
 

--- a/lua/ttt2/libraries/buttons.lua
+++ b/lua/ttt2/libraries/buttons.lua
@@ -12,6 +12,7 @@ button = {}
 local validButtons = {
     "func_button",
     "func_rot_button",
+    "momentary_rot_button",
 }
 
 if SERVER then

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -702,6 +702,11 @@ function targetid.HUDDrawTargetIDButtons(tData)
         tData:SetTitle(TryT("name_button_rotating"))
         tData:SetSubtitle(ParT("button_rotating", key_params))
     end
+
+    if ent:IsMomentaryRotatingButton() then
+        tData:SetTitle(TryT("name_button_momentary_rotating"))
+        tData:SetSubtitle(ParT("button_momentary_rotating", key_params))
+    end
 end
 
 ---


### PR DESCRIPTION
Added momentary_rot_button to TargetID so that this third type of button also displays the usual interact text when hovering over.