### PR TITLE
Fix Markervision PVS Edgecase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added momentary_rot_button to targetID (by @MrXonte)
 
+### Fixed
+
+- Fixed markerVision not relaying engine-native entities out of PVS (by @MrXonte)
+
 ## [v0.14.6b](https://github.com/TTT-2/TTT2/tree/v0.14.6b) (2026-04-06)
 
 ### Added

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -239,14 +239,18 @@ if SERVER then
     -- push is a cheap no-op.
     -- @realm server
     hook.Add("SetupPlayerVisibility", "TTT2MarkerVisionForcePVS", function(ply, viewEntity)
-        if not IsValid(ply) then return end
+        if not IsValid(ply) then
+            return
+        end
 
         for i = 1, #markerVision.registry do
             local mvObject = markerVision.registry[i]
             local mvObjectData = mvObject.data
             local ent = mvObjectData.ent
 
-            if not IsValid(ent) then continue end
+            if not IsValid(ent) then
+                continue
+            end
 
             local visibleFor = mvObjectData.visibleFor
             local owner = mvObjectData.owner

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -222,6 +222,59 @@ if SERVER then
             end
         end
     end
+
+    ---
+    -- Force-add every marker-tracked entity's origin into the PVS of each
+    -- player that should see the marker.
+    --
+    -- markerVision.Add overrides ent.UpdateTransmitState to TRANSMIT_ALWAYS,
+    -- which works for scripted entities (SENTs). However, engine-native
+    -- entities (prop_ragdoll, prop_physics, prop_door_rotating, ...) implement
+    -- UpdateTransmitState in C++ and silently ignore the Lua field, so they
+    -- remain PVS-gated. Without this hook, a marker placed on an out-of-PVS
+    -- engine entity is never networked to the receiver and the wallhack icon
+    -- never renders until the player happens to walk into PVS.
+    --
+    -- For SENTs whose transmit override already took effect, the extra PVS
+    -- push is a cheap no-op.
+    -- @realm server
+    hook.Add("SetupPlayerVisibility", "TTT2MarkerVisionForcePVS", function(ply, viewEntity)
+        if not IsValid(ply) then return end
+
+        for i = 1, #markerVision.registry do
+            local mvObject = markerVision.registry[i]
+            local mvObjectData = mvObject.data
+            local ent = mvObjectData.ent
+
+            if not IsValid(ent) then continue end
+
+            local visibleFor = mvObjectData.visibleFor
+            local owner = mvObjectData.owner
+            local shouldPush = false
+
+            if visibleFor == VISIBLE_FOR_ALL then
+                shouldPush = true
+            elseif visibleFor == VISIBLE_FOR_PLAYER then
+                shouldPush = (owner == ply)
+            elseif visibleFor == VISIBLE_FOR_ROLE then
+                if IsPlayer(owner) then
+                    shouldPush = IsValid(owner) and owner:GetSubRole() == ply:GetSubRole()
+                else
+                    shouldPush = owner == ply:GetSubRole()
+                end
+            elseif visibleFor == VISIBLE_FOR_TEAM then
+                if IsPlayer(owner) then
+                    shouldPush = IsValid(owner) and owner:GetTeam() == ply:GetTeam()
+                else
+                    shouldPush = owner == ply:GetTeam()
+                end
+            end
+
+            if shouldPush then
+                AddOriginToPVS(ent:GetPos())
+            end
+        end
+    end)
 end
 
 if CLIENT then


### PR DESCRIPTION
Fixes an edgecase of markervision with engine-native entities not getting relayed properly when out of PVS. I encountered specifically when using markervision on corpses while playin the vulture. Bodies often did not show up on MV when the corpse that should get markervisioned was too far away (out of PVS).